### PR TITLE
Replace googletest with cppunit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
         pushd build
         cmake ..
         make -j
+        ctest -VV
         cpack
         popd
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,33 +1,21 @@
 name: Vvflow CI
 
-on: push
+on: pull_request
 
 jobs:
   build-ubuntu-bionic:
     runs-on: ubuntu-18.04
     env:
-      APT_PACKAGES: liblapack-dev
+      APT_PACKAGES: liblapack-dev gnuplot
     steps:
     - name: Git checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
-    - name: Install apt packages
+    - name: Install dependencies
       run: |
         sudo apt-get install ${APT_PACKAGES}
-
-    - name: Cache pip packages
-      id: cache-pip
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: bionic-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: bionic-pip-
-
-    - name: Install pip packages
-      if: steps.cache-pip.outputs.cache-hit != 'true'
-      run: |
         pip3 install -r pytest/requirements.txt
 
     - name: Cache CMakeFiles

--- a/ExternalProjects.cmake
+++ b/ExternalProjects.cmake
@@ -4,6 +4,7 @@ set(LUA_VERSION 5.2.4)
 set(ZLIB_VERSION 1.2.11)
 set(HDF5_VERSION 1.10.6)
 set(LIBARCHIVE_VERSION 3.4.3)
+set(CPPUNIT_VERSION 1.15.1)
 
 string(CONCAT HDF5_URL
     "https://support.hdfgroup.org/ftp/HDF5/releases/"
@@ -72,25 +73,6 @@ set(LUA_INCLUDE_DIRS ${source_dir}/src)
 set(LUA_LIBRARIES ${source_dir}/src/liblua.a)
 
 #
-# GoogleTest
-#
-ExternalProject_Add(googletest
-    URL https://vvflow.github.io/vvflow-deps/googletest/v1.10.x.tar.gz
-        https://github.com/google/googletest/archive/v1.10.x.tar.gz
-    URL_MD5 58e27196e6423e330e5caadacfe3557b
-    CMAKE_ARGS
-        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-)
-
-ExternalProject_Get_Property(googletest install_dir)
-set(GTEST_INCLUDE_DIRS ${install_dir}/include)
-set(GTEST_LIBRARIES
-    ${install_dir}/lib/libgtest.a
-    ${install_dir}/lib/libgtest_main.a
-    -lpthread
-)
-
-#
 # LibArchive
 #
 ExternalProject_Add(libarchive
@@ -120,3 +102,22 @@ ExternalProject_Add(libarchive
 ExternalProject_Get_Property(libarchive install_dir)
 set(LIBARCHIVE_INCLUDE_DIRS ${install_dir}/include)
 set(LIBARCHIVE_LIBRARIES ${install_dir}/lib/libarchive.a)
+
+#
+# CppUnit
+#
+ExternalProject_Add(cppunit
+    URL https://vvflow.github.io/vvflow-deps/cppunit-${CPPUNIT_VERSION}.tar.gz
+        http://dev-www.libreoffice.org/src/cppunit-${CPPUNIT_VERSION}.tar.gz
+    URL_MD5 "9dc669e6145cadd9674873e24943e6dd"
+    CONFIGURE_COMMAND <SOURCE_DIR>/configure
+        --prefix=<INSTALL_DIR>
+        --disable-doxygen
+        --disable-docs
+        # shared is enough for testing
+        --enable-shared
+        --disable-static
+)
+ExternalProject_Get_Property(cppunit install_dir)
+set(CPPUNIT_INCLUDE_DIRS ${install_dir}/include)
+set(CPPUNIT_LIBRARIES ${install_dir}/lib/libcppunit.so)

--- a/libvvhd/test/CMakeLists.txt
+++ b/libvvhd/test/CMakeLists.txt
@@ -2,13 +2,13 @@ cmake_minimum_required (VERSION 3.0)
 
 include_directories(
 	${LIBVVHD_INCLUDE_DIRS}
-	${GTEST_INCLUDE_DIRS}
+	${CPPUNIT_INCLUDE_DIRS}
 	# ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_executable(libvvhd_test main.cpp)
-add_dependencies(libvvhd_test googletest)
-target_link_libraries(libvvhd_test vvhd ${GTEST_LIBRARIES})
+add_dependencies(libvvhd_test cppunit)
+target_link_libraries(libvvhd_test vvhd ${CPPUNIT_LIBRARIES})
 set_target_properties(libvvhd_test PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests/
 )

--- a/libvvhd/test/expect.hpp
+++ b/libvvhd/test/expect.hpp
@@ -1,18 +1,34 @@
-#define EXPECT_THROW_MSG(statement, expected_exception, expected_what)                    \
-  try                                                                                     \
-  {                                                                                       \
-    statement;                                                                            \
-    FAIL() << "Expected: " #statement " throws an exception of type " #expected_exception \
-              ".\n"                                                                       \
-              "  Actual: it throws nothing.";                                             \
-  }                                                                                       \
-  catch (const expected_exception& e)                                                     \
-  {                                                                                       \
-    EXPECT_EQ(expected_what, std::string{e.what()});                                      \
-  }                                                                                       \
-  catch (...)                                                                             \
-  {                                                                                       \
-    FAIL() << "Expected: " #statement " throws an exception of type " #expected_exception \
-              ".\n"                                                                       \
-              "  Actual: it throws a different type.";                                    \
+#define EXPECT_THROW_MSG(statement, expected_exception, expected_what)         \
+  do {                                                                         \
+    bool cpputCorrectExceptionThrown_ = false;                                 \
+    CPPUNIT_NS::Message cpputMsg_( "expected exception not thrown" );          \
+    cpputMsg_.addDetail( CPPUNIT_NS::AdditionalMessage() );                    \
+    cpputMsg_.addDetail( "Expected: "                                          \
+                         CPPUNIT_GET_PARAMETER_STRING( expected_exception ) ); \
+                                                                               \
+    try {                                                                      \
+      statement;                                                               \
+    } catch ( const expected_exception &e ) {                                  \
+      CPPUNIT_ASSERT_EQUAL(std::string(expected_what), std::string(e.what())); \
+      cpputCorrectExceptionThrown_ = true;                                     \
+    } catch ( const std::exception &e) {                                       \
+      cpputMsg_.addDetail( "Actual  : " +                                      \
+                           CPPUNIT_EXTRACT_EXCEPTION_TYPE_( e,                 \
+                                       "std::exception or derived") );         \
+      cpputMsg_.addDetail( std::string("What()  : ") + e.what() );             \
+    } catch ( ... ) {                                                          \
+      cpputMsg_.addDetail( "Actual  : unknown.");                              \
+    }                                                                          \
+                                                                               \
+    if ( cpputCorrectExceptionThrown_ )                                        \
+      break;                                                                   \
+                                                                               \
+    CPPUNIT_NS::Asserter::fail( cpputMsg_,                                     \
+                                CPPUNIT_SOURCELINE() );                        \
+ } while ( false )
+
+
+#define EXPECT_EQUAL(x, y)                                                     \
+  if (!std::isnan(x) || !std::isnan(y)) {                                      \
+      CPPUNIT_ASSERT_EQUAL(x, y);                                              \
   }

--- a/libvvhd/test/main.cpp
+++ b/libvvhd/test/main.cpp
@@ -1,12 +1,18 @@
 #include <cppunit/ui/text/TestRunner.h>
 #include "test_TVec.hpp"
+#include "test_TEval.hpp"
+#include "test_TBody.hpp"
 #include "test_TVec3D.hpp"
+#include "test_XField.hpp"
 
 int main( int argc, char **argv)
 {
   CppUnit::TextUi::TestRunner runner;
   runner.addTest( TVecSuite::suite() );
+  runner.addTest( TEvalSuite::suite() );
+  runner.addTest( TBodySuite::suite() );
   runner.addTest( TVec3DSuite::suite() );
-  runner.run();
-  return 0;
+  runner.addTest( XFieldSuite::suite() );
+  bool ok = runner.run();
+  return ok ? 0 : 1;
 }

--- a/libvvhd/test/main.cpp
+++ b/libvvhd/test/main.cpp
@@ -1,10 +1,12 @@
+#include <cppunit/ui/text/TestRunner.h>
 #include "test_TVec.hpp"
 #include "test_TVec3D.hpp"
-#include "test_TEval.hpp"
-#include "test_TBody.hpp"
-#include "test_XField.hpp"
 
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+int main( int argc, char **argv)
+{
+  CppUnit::TextUi::TestRunner runner;
+  runner.addTest( TVecSuite::suite() );
+  runner.addTest( TVec3DSuite::suite() );
+  runner.run();
+  return 0;
 }

--- a/libvvhd/test/test_TBody.hpp
+++ b/libvvhd/test/test_TBody.hpp
@@ -1,13 +1,7 @@
 #pragma once
 
+#include <cppunit/extensions/HelperMacros.h>
 #include "TBody.hpp"
-
-#include <gtest/gtest.h>
-// #include <stdexcept>
-
-// using std::shared_ptr;
-// using std::make_shared;
-
 
 //  _________
 // |j        |
@@ -17,18 +11,27 @@
 // |         |
 // |_________|
 
-class TBodyTest : public ::testing::Test {
-public:
-    TBodyTest():
-        dummy(),
-        jimmy(),
-        thin() {}
+class TBodySuite : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE( TBodySuite );
+    CPPUNIT_TEST( TestThinBody );
+    CPPUNIT_TEST( TestAttached );
+    CPPUNIT_TEST( TestCopyConstructor );
+    CPPUNIT_TEST_SUITE_END();
+
 protected:
     std::shared_ptr<TBody> dummy;
     std::shared_ptr<TBody> jimmy;
     std::shared_ptr<TBody> thin;
 
-    void SetUp()
+    void TestThinBody();
+    void TestAttached();
+    void TestCopyConstructor();
+
+public:
+    TBodySuite(): dummy(), jimmy(), thin() {}
+
+    void setUp()
     {
         dummy = std::make_shared<TBody>();
         dummy->label = "Dummy";
@@ -63,7 +66,8 @@ protected:
         thin->doUpdateSegments();
         thin->doFillProperties();
     }
-    void TearDown()
+
+    void tearDown()
     {
         dummy.reset();
         jimmy.reset();
@@ -71,28 +75,28 @@ protected:
     }
 };
 
-TEST_F(TBodyTest, ThinBody)
+void TBodySuite::TestThinBody()
 {
-    EXPECT_EQ(0.0, thin->get_area());
-    EXPECT_EQ(0.0, thin->get_moi_cofm());
-    EXPECT_EQ(0.0, thin->get_moi_axis());
-    EXPECT_EQ(2.0, thin->get_slen());
+    CPPUNIT_ASSERT_EQUAL(thin->get_area(), 0.0);
+    CPPUNIT_ASSERT_EQUAL(thin->get_moi_cofm(), 0.0);
+    CPPUNIT_ASSERT_EQUAL(thin->get_moi_axis(), 0.0);
+    CPPUNIT_ASSERT_EQUAL(thin->get_slen(), 2.0);
     TVec cofm = thin->get_cofm();
-    EXPECT_EQ(0.5, cofm.x);
-    EXPECT_EQ(1.0, cofm.y);
+    CPPUNIT_ASSERT_EQUAL(cofm.x, 0.5);
+    CPPUNIT_ASSERT_EQUAL(cofm.y, 1.0);
 }
 
-TEST_F(TBodyTest, TAttTest)
+void TBodySuite::TestAttached()
 {
     // won't compile: use of deleted function 'TAtt::TAtt()'
     // TAtt att;
 
-    EXPECT_EQ(true, TAtt(0., 0., true).slip);
-    EXPECT_EQ(false, TAtt(0., 0., false).slip);
-    EXPECT_EQ(false, TAtt(0., 0.).slip);
-    EXPECT_EQ(true, TAtt(TVec(0., 0.), true).slip);
-    EXPECT_EQ(false, TAtt(TVec(0., 0.), false).slip);
-    EXPECT_EQ(false, TAtt(TVec(0., 0.)).slip);
+    CPPUNIT_ASSERT_EQUAL(1U, TAtt(0., 0., true).slip);
+    CPPUNIT_ASSERT_EQUAL(0U, TAtt(0., 0., false).slip);
+    CPPUNIT_ASSERT_EQUAL(0U, TAtt(0., 0.).slip);
+    CPPUNIT_ASSERT_EQUAL(1U, TAtt(TVec(0., 0.), true).slip);
+    CPPUNIT_ASSERT_EQUAL(0U, TAtt(TVec(0., 0.), false).slip);
+    CPPUNIT_ASSERT_EQUAL(0U, TAtt(TVec(0., 0.)).slip);
 
     TAtt a1 = TAtt(0., 0., true);
     a1.eq_no = 7;
@@ -100,71 +104,69 @@ TEST_F(TBodyTest, TAttTest)
     TAtt a3 = TAtt(0., 0.); a3 = a1;
     TAtt a4 = std::move(a1);
     TAtt a5 = TAtt(0., 0.); a5 = std::move(a1);
-    EXPECT_EQ(7U, a1.eq_no);
-    EXPECT_EQ(7U, a2.eq_no);
-    EXPECT_EQ(7U, a3.eq_no);
-    EXPECT_EQ(7U, a4.eq_no);
-    EXPECT_EQ(7U, a5.eq_no);
+    CPPUNIT_ASSERT_EQUAL(7U, a1.eq_no);
+    CPPUNIT_ASSERT_EQUAL(7U, a2.eq_no);
+    CPPUNIT_ASSERT_EQUAL(7U, a3.eq_no);
+    CPPUNIT_ASSERT_EQUAL(7U, a4.eq_no);
+    CPPUNIT_ASSERT_EQUAL(7U, a5.eq_no);
 }
 
-::testing::AssertionResult checkDummy(std::shared_ptr<TBody> dummy)
+static void checkDummy(std::shared_ptr<TBody> dummy)
 {
     if (!dummy) {
-        return ::testing::AssertionFailure() << " invalid dummy";
+        CPPUNIT_FAIL(" invalid dummy");
     }
-    EXPECT_EQ(4U, dummy->size());
-    EXPECT_EQ(false, dummy->isInsideValid());
-    EXPECT_EQ(8.0, dummy->get_slen());
-    EXPECT_EQ(4.0, dummy->get_area());
-    EXPECT_EQ(0.0, dummy->get_cofm().abs2());
-    EXPECT_EQ(16.0/6.0, dummy->get_moi_cofm());
-    EXPECT_TRUE((dummy->get_axis()-TVec(1., 1.)).iszero());
-    EXPECT_EQ(32, dummy->eq_forces_no);
-    EXPECT_TRUE(dummy->root_body.expired());
-    EXPECT_EQ(
+    CPPUNIT_ASSERT_EQUAL((size_t)4, dummy->size());
+    CPPUNIT_ASSERT_EQUAL(false, dummy->isInsideValid());
+    CPPUNIT_ASSERT_EQUAL(8.0, dummy->get_slen());
+    CPPUNIT_ASSERT_EQUAL(4.0, dummy->get_area());
+    CPPUNIT_ASSERT_EQUAL(0.0, dummy->get_cofm().abs2());
+    CPPUNIT_ASSERT_EQUAL(16.0/6.0, dummy->get_moi_cofm());
+    CPPUNIT_ASSERT((dummy->get_axis()-TVec(1., 1.)).iszero());
+    CPPUNIT_ASSERT_EQUAL(32, dummy->eq_forces_no);
+    CPPUNIT_ASSERT(dummy->root_body.expired());
+    CPPUNIT_ASSERT_EQUAL(
         &dummy->alist.front(),
         dummy->isPointInvalid(TVec(0.9, 0.0))
     );
-    EXPECT_EQ(
-        nullptr,
+    CPPUNIT_ASSERT_EQUAL(
+        (TAtt*)nullptr,
         dummy->isPointInvalid(TVec(1.1, 0.0))
     );
-    return ::testing::AssertionSuccess();
 }
 
-::testing::AssertionResult checkJimmy(std::shared_ptr<TBody> jimmy)
+static void checkJimmy(std::shared_ptr<TBody> jimmy)
 {
     if (!jimmy) {
-        return ::testing::AssertionFailure() << " invalid jimmy";
+        CPPUNIT_FAIL(" invalid jimmy");
     }
-    EXPECT_EQ(4U, jimmy->size());
-    EXPECT_EQ(true, jimmy->isInsideValid());
-    EXPECT_EQ(16.0, jimmy->get_slen());
-    EXPECT_EQ(-16.0, jimmy->get_area());
-    EXPECT_EQ(0.0, jimmy->get_cofm().abs2());
-    EXPECT_EQ(-256.0/6.0, jimmy->get_moi_cofm());
-    EXPECT_TRUE((jimmy->get_axis()-TVec(2., 0.)).iszero());
-    EXPECT_EQ(69, jimmy->eq_forces_no);
-    EXPECT_TRUE(checkDummy(jimmy->root_body.lock()));
-    EXPECT_EQ(
-        nullptr,
+    CPPUNIT_ASSERT_EQUAL((size_t)4, jimmy->size());
+    CPPUNIT_ASSERT_EQUAL(true, jimmy->isInsideValid());
+    CPPUNIT_ASSERT_EQUAL(16.0, jimmy->get_slen());
+    CPPUNIT_ASSERT_EQUAL(-16.0, jimmy->get_area());
+    CPPUNIT_ASSERT_EQUAL(0.0, jimmy->get_cofm().abs2());
+    CPPUNIT_ASSERT_EQUAL(-256.0/6.0, jimmy->get_moi_cofm());
+    CPPUNIT_ASSERT((jimmy->get_axis()-TVec(2., 0.)).iszero());
+    CPPUNIT_ASSERT_EQUAL(69, jimmy->eq_forces_no);
+    checkDummy(jimmy->root_body.lock());
+    CPPUNIT_ASSERT_EQUAL(
+        (TAtt*)nullptr,
         jimmy->isPointInvalid(TVec(1.9, 0.0))
     );
-    EXPECT_EQ(
+    CPPUNIT_ASSERT_EQUAL(
         &jimmy->alist.front(),
         jimmy->isPointInvalid(TVec(2.1, 0.0))
     );
-    return ::testing::AssertionSuccess();
 }
 
-TEST_F(TBodyTest, ConstructorCopy)
+void TBodySuite::TestCopyConstructor()
 {
     std::shared_ptr<TBody> ndummy = std::make_shared<TBody>(*dummy);
     std::shared_ptr<TBody>& njimmy = dummy;
     *njimmy = *jimmy;
     njimmy->root_body = ndummy;
-    EXPECT_TRUE(checkDummy(ndummy));
-    EXPECT_TRUE(checkJimmy(njimmy));
+    checkDummy(ndummy);
+    checkJimmy(njimmy);
 
     // won't compile:
     // use of deleted function 'TBody::TBody(TBody&&)'

--- a/libvvhd/test/test_TEval.hpp
+++ b/libvvhd/test/test_TEval.hpp
@@ -1,130 +1,148 @@
 #pragma once
 
+#include <cppunit/extensions/HelperMacros.h>
 #include "TEval.hpp"
+#include "expect.hpp"
 
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
 #include <stdexcept>
+#include <limits>
 #include <map>
 
-class TEvalTest : public ::testing::Test {};
+class TEvalSuite : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE( TEvalSuite );
+    CPPUNIT_TEST( TestDefaultConstructor );
+    CPPUNIT_TEST( TestStringConstructor );
+    CPPUNIT_TEST( TestEvaluateConstants );
+    CPPUNIT_TEST( TestEvaluateFunctions );
+    CPPUNIT_TEST_SUITE_END();
+protected:
+    void TestDefaultConstructor();
+    void TestStringConstructor();
+    void TestEvaluateConstants();
+    void TestEvaluateFunctions();
+};
 
-TEST_F(TEvalTest, ConstructDefault)
+void TEvalSuite::TestDefaultConstructor()
 {
     TEval eval;
-    EXPECT_EQ("", std::string(eval));
-    EXPECT_EQ(0, eval.eval(-1));
-    EXPECT_EQ(0, eval.eval(0));
-    EXPECT_EQ(0, eval.eval(1));
-    EXPECT_EQ(0, eval.eval(100));
+    // CPPUNIT_ASSERT_EQUAL(v0.x, 0.);
+    CPPUNIT_ASSERT_EQUAL(std::string(eval), std::string(""));
+    CPPUNIT_ASSERT_EQUAL(eval.eval(-1), 0.);
+    CPPUNIT_ASSERT_EQUAL(eval.eval(0), 0.);
+    CPPUNIT_ASSERT_EQUAL(eval.eval(1), 0.);
+    CPPUNIT_ASSERT_EQUAL(eval.eval(100), 0.);
 }
 
-TEST_F(TEvalTest, ConstructWithString)
+void TEvalSuite::TestStringConstructor()
 {
     // malformed expression
-    EXPECT_THROW(TEval eval(")");, std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(TEval eval(")");, std::invalid_argument);
     // invalid expression
-    EXPECT_THROW(TEval eval("a+1");, std::invalid_argument);
-    EXPECT_THROW(TEval eval("t(1)");, std::invalid_argument);
-    EXPECT_THROW(TEval eval("x(1)");, std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(TEval eval("a+1");, std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(TEval eval("t(1)");, std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(TEval eval("x(1)");, std::invalid_argument);
 
     TEval eval("t-t");
     eval = "t+1";
     // invalid expression should not spoil evaluator
-    EXPECT_THROW(eval = "b+1";, std::invalid_argument);
-    EXPECT_EQ("t+1", std::string(eval));
-    EXPECT_EQ(2, eval.eval(1));
+    CPPUNIT_ASSERT_THROW(eval = "b+1";, std::invalid_argument);
+    CPPUNIT_ASSERT_EQUAL(std::string(eval), std::string("t+1"));
+    CPPUNIT_ASSERT_EQUAL(eval.eval(1), 2.0);
     // valid expression should drop cache
-    EXPECT_NO_THROW(eval = "2+t";);
-    EXPECT_EQ("2+t", std::string(eval));
-    EXPECT_EQ(3, eval.eval(1));
+    CPPUNIT_ASSERT_NO_THROW(eval = "2+t";);
+    CPPUNIT_ASSERT_EQUAL(std::string(eval), std::string("2+t"));
+    CPPUNIT_ASSERT_EQUAL(eval.eval(1), 3.0);
 
     // copy and move compile
     TEval e1("sin(t)");
     TEval e2(e1);
-    EXPECT_EQ(e2.eval(0.1), std::sin(0.1));
+    CPPUNIT_ASSERT_EQUAL(e2.eval(0.1), std::sin(0.1));
 
     TEval e3; e3 = e1;
-    EXPECT_EQ(e3.eval(0.2), std::sin(0.2));
+    CPPUNIT_ASSERT_EQUAL(e3.eval(0.2), std::sin(0.2));
 
     TEval e4(std::move(e1));
-    EXPECT_EQ(e4.eval(0.3), std::sin(0.3));
+    CPPUNIT_ASSERT_EQUAL(e4.eval(0.3), std::sin(0.3));
 
     TEval e5; e5 = std::move(e1);
-    EXPECT_EQ(e5.eval(0.4), std::sin(0.4));
+    CPPUNIT_ASSERT_EQUAL(e5.eval(0.4), std::sin(0.4));
 }
 
-TEST_F(TEvalTest, EvaluateConstants)
+void TEvalSuite::TestEvaluateConstants()
 {
+    // Test the tests
+    EXPECT_EQUAL(
+        std::numeric_limits<double>::quiet_NaN(),
+        std::numeric_limits<double>::quiet_NaN()
+    );
+    CPPUNIT_ASSERT_THROW(EXPECT_EQUAL(
+        std::numeric_limits<double>::quiet_NaN(),
+        std::numeric_limits<double>::infinity()
+    ), CPPUNIT_NS::Exception);
+
     const double pi = acos(-1);
 
-    #define CHECK(x, y) EXPECT_THAT( \
-        TEval(x).eval(0), \
-        ::testing::NanSensitiveDoubleEq(y) \
-    )
+    #define CHECK(x, y) EXPECT_EQUAL(TEval(x).eval(0), y)
     CHECK("e", exp(1));
-    CHECK("log2e", 1.L/log(2));
-    CHECK("log10e", 1.L/log(10));
+    CHECK("log2e", 1./log(2));
+    CHECK("log10e", 1./log(10));
     CHECK("ln2", log(2));
     CHECK("ln10", log(10));
     CHECK("pi", pi);
-    CHECK("pi_2", pi/2.L);
-    CHECK("pi_4", pi/4.L);
-    CHECK("sqrt2", sqrt(2.L));
-    CHECK("sqrt1_2", sqrt(0.5L));
+    CHECK("pi_2", pi/2.);
+    CHECK("pi_4", pi/4.);
+    CHECK("sqrt2", sqrt(2.));
+    CHECK("sqrt1_2", sqrt(0.5));
     #undef CHECK
 }
 
-TEST_F(TEvalTest, EvaluateFunctions)
+static void CheckEvaluation(std::string expr, double fn(double))
 {
-    std::map<const char*, double(*)(double)> functions = {
-        {"exp(t)", exp},
-        {"log(t)", log},
-        {"sqrt(t)", sqrt},
-        {"sin(t)", sin},
-        {"cos(t)", cos},
-        {"tan(t)", tan},
-        {"asin(t)", asin},
-        {"acos(t)", acos},
-        {"atan(t)", atan},
-        {"sinh(t)", sinh},
-        {"cosh(t)", cosh},
-        {"tanh(t)", tanh},
+    #define CHECK(x) EXPECT_EQUAL(TEval(expr).eval(x), fn(x))
 
-        {"abs(t)", abs},
-        {"step(t)", [](double x) -> double {
-            if (isnan(x)) return x;
-            return x>=0 ? 1 : 0;
-        }},
-        {"delta(t)", [](double x) -> double {
-            if (isnan(x)) return x;
-            return x==0 ? std::numeric_limits<double>::infinity() : 0;
-        }},
-        {"nandelta(t)", [](double x) -> double {
-            if (isnan(x)) return x;
-            return x==0 ? std::numeric_limits<double>::quiet_NaN() : 0;
-        }},
-        {"erf(t)", erf}
-    };
+    CHECK(0.0);
+    CHECK(1.0);
+    CHECK(2.0);
+    CHECK(0.5);
+    CHECK(-1.0);
+    CHECK(std::numeric_limits<double>::min()); // DBL_MIN ~1e-308
+    CHECK(std::numeric_limits<double>::max()); // DBL_MAX ~1e+308
+    CHECK(std::numeric_limits<double>::lowest()); // -DBL_MAX
+    CHECK(std::numeric_limits<double>::epsilon());
+    CHECK(std::numeric_limits<double>::infinity());
+    CHECK(std::numeric_limits<double>::quiet_NaN());
 
-    for (const auto& p: functions) {
-        #define CHECK(x) EXPECT_THAT( \
-            TEval(p.first).eval(x), \
-            ::testing::NanSensitiveDoubleEq(p.second(x)) \
-        )
+    #undef CHECK
+}
 
-        CHECK(0.0);
-        CHECK(1.0);
-        CHECK(2.0);
-        CHECK(0.5);
-        CHECK(-1.0);
-        CHECK(std::numeric_limits<double>::min()); // DBL_MIN ~1e-308
-        CHECK(std::numeric_limits<double>::max()); // DBL_MAX ~1e+308
-        CHECK(std::numeric_limits<double>::lowest()); // -DBL_MAX
-        CHECK(std::numeric_limits<double>::epsilon());
-        CHECK(std::numeric_limits<double>::infinity());
-        CHECK(std::numeric_limits<double>::quiet_NaN());
+void TEvalSuite::TestEvaluateFunctions()
+{
+    CheckEvaluation("exp(t)", exp);
+    CheckEvaluation("log(t)", log);
+    CheckEvaluation("sin(t)", sin);
+    CheckEvaluation("cos(t)", cos);
+    CheckEvaluation("tan(t)", tan);
+    CheckEvaluation("erf(t)", erf);
+    CheckEvaluation("abs(t)", fabs);
+    CheckEvaluation("sqrt(t)", sqrt);
+    CheckEvaluation("asin(t)", asin);
+    CheckEvaluation("acos(t)", acos);
+    CheckEvaluation("atan(t)", atan);
+    CheckEvaluation("sinh(t)", sinh);
+    CheckEvaluation("cosh(t)", cosh);
+    CheckEvaluation("tanh(t)", tanh);
 
-        #undef CHECK
-    }
+    CheckEvaluation("step(t)", [](double x) -> double {
+        if (std::isnan(x)) return x;
+        return x>=0 ? 1 : 0;
+    });
+    CheckEvaluation("delta(t)", [](double x) -> double {
+        if (std::isnan(x)) return x;
+        return x==0 ? std::numeric_limits<double>::infinity() : 0;
+    });
+    CheckEvaluation("nandelta(t)", [](double x) -> double {
+        if (std::isnan(x)) return x;
+        return x==0 ? std::numeric_limits<double>::quiet_NaN() : 0;
+    });
 }

--- a/libvvhd/test/test_TVec.hpp
+++ b/libvvhd/test/test_TVec.hpp
@@ -1,60 +1,68 @@
 #pragma once
 
+#include <cppunit/extensions/HelperMacros.h>
 #include "TVec.hpp"
 
-#include <gtest/gtest.h>
+class TVecSuite : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE( TVecSuite );
+    CPPUNIT_TEST( TestConstructor );
+    CPPUNIT_TEST_SUITE_END();
+protected:
+    void TestConstructor();
+};
 
-class TVecTest : public ::testing::Test {};
+// CPPUNIT_TEST_SUITE_REGISTRATION( TVecSuite );
 
-TEST_F(TVecTest, Construct)
+void TVecSuite::TestConstructor()
 {
     TVec v0;
-    EXPECT_EQ(0, v0.x);
-    EXPECT_EQ(0, v0.y);
+    CPPUNIT_ASSERT_EQUAL(v0.x, 0.);
+    CPPUNIT_ASSERT_EQUAL(v0.y, 0.);
 
     {
         TVec v1(1, 1);
-        EXPECT_EQ(1, v1.x);
-        EXPECT_EQ(1, v1.y);
+        CPPUNIT_ASSERT_EQUAL(v1.x, 1.);
+        CPPUNIT_ASSERT_EQUAL(v1.y, 1.);
     }
 
     /* copy constructor */ {
         TVec v2(v0);
         v2.x = 2;
         v2.y = 2;
-        EXPECT_EQ(2, v2.x);
-        EXPECT_EQ(2, v2.y);
-        EXPECT_EQ(0, v0.x);
-        EXPECT_EQ(0, v0.y);
+        CPPUNIT_ASSERT_EQUAL(v2.x, 2.);
+        CPPUNIT_ASSERT_EQUAL(v2.y, 2.);
+        CPPUNIT_ASSERT_EQUAL(v0.x, 0.);
+        CPPUNIT_ASSERT_EQUAL(v0.y, 0.);
     }
 
     /* copy assignment */ {
         TVec v3 = v0;
         v3.x = 3;
         v3.y = 3;
-        EXPECT_EQ(3, v3.x);
-        EXPECT_EQ(3, v3.y);
-        EXPECT_EQ(0, v0.x);
-        EXPECT_EQ(0, v0.y);
+        CPPUNIT_ASSERT_EQUAL(v3.x, 3.);
+        CPPUNIT_ASSERT_EQUAL(v3.y, 3.);
+        CPPUNIT_ASSERT_EQUAL(v0.x, 0.);
+        CPPUNIT_ASSERT_EQUAL(v0.y, 0.);
     }
 
     /* move constructor */ {
         TVec v4(std::move(v0));
         v4.x = 4;
         v4.y = 4;
-        EXPECT_EQ(4, v4.x);
-        EXPECT_EQ(4, v4.y);
-        EXPECT_EQ(0, v0.x);
-        EXPECT_EQ(0, v0.y);
+        CPPUNIT_ASSERT_EQUAL(v4.x, 4.);
+        CPPUNIT_ASSERT_EQUAL(v4.y, 4.);
+        CPPUNIT_ASSERT_EQUAL(v0.x, 0.);
+        CPPUNIT_ASSERT_EQUAL(v0.y, 0.);
     }
 
     /* move assignment */ {
         TVec v5 = std::move(v0);
         v5.x = 5;
         v5.y = 5;
-        EXPECT_EQ(5, v5.x);
-        EXPECT_EQ(5, v5.y);
-        EXPECT_EQ(0, v0.x);
-        EXPECT_EQ(0, v0.y);
+        CPPUNIT_ASSERT_EQUAL(v5.x, 5.);
+        CPPUNIT_ASSERT_EQUAL(v5.y, 5.);
+        CPPUNIT_ASSERT_EQUAL(v0.x, 0.);
+        CPPUNIT_ASSERT_EQUAL(v0.y, 0.);
     }
 }

--- a/libvvhd/test/test_TVec3D.hpp
+++ b/libvvhd/test/test_TVec3D.hpp
@@ -1,23 +1,31 @@
 #pragma once
 
+#include <cppunit/extensions/HelperMacros.h>
 #include "TVec3D.hpp"
 
-#include <gtest/gtest.h>
+class TVec3DSuite : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE( TVec3DSuite );
+    CPPUNIT_TEST( TestConstructor );
+    CPPUNIT_TEST_SUITE_END();
+protected:
+    void TestConstructor();
+};
 
-class TVec3DTest : public ::testing::Test {};
+// CPPUNIT_TEST_SUITE_REGISTRATION( TVec3DSuite );
 
-TEST_F(TVec3DTest, Construct)
+void TVec3DSuite::TestConstructor()
 {
     TVec3D v0;
-    EXPECT_EQ(0, v0.r.x);
-    EXPECT_EQ(0, v0.r.y);
-    EXPECT_EQ(0, v0.o);
+    CPPUNIT_ASSERT_EQUAL(v0.r.x, 0.);
+    CPPUNIT_ASSERT_EQUAL(v0.r.y, 0.);
+    CPPUNIT_ASSERT_EQUAL(v0.o,   0.);
 
     {
         TVec3D v1(1.1, 1.2, 1.3);
-        EXPECT_EQ(1.1, v1.r.x);
-        EXPECT_EQ(1.2, v1.r.y);
-        EXPECT_EQ(1.3, v1.o);
+        CPPUNIT_ASSERT_EQUAL(v1.r.x, 1.1);
+        CPPUNIT_ASSERT_EQUAL(v1.r.y, 1.2);
+        CPPUNIT_ASSERT_EQUAL(v1.o,   1.3);
     }
 
     /* copy constructor */ {
@@ -25,12 +33,12 @@ TEST_F(TVec3DTest, Construct)
         v2.r.x = 2.1;
         v2.r.y = 2.2;
         v2.o = 2.3;
-        EXPECT_EQ(2.1, v2.r.x);
-        EXPECT_EQ(2.2, v2.r.y);
-        EXPECT_EQ(2.3, v2.o);
-        EXPECT_EQ(0, v0.r.x);
-        EXPECT_EQ(0, v0.r.y);
-        EXPECT_EQ(0, v0.o);
+        CPPUNIT_ASSERT_EQUAL(v2.r.x, 2.1);
+        CPPUNIT_ASSERT_EQUAL(v2.r.y, 2.2);
+        CPPUNIT_ASSERT_EQUAL(v2.o,   2.3);
+        CPPUNIT_ASSERT_EQUAL(v0.r.x, 0.0);
+        CPPUNIT_ASSERT_EQUAL(v0.r.y, 0.0);
+        CPPUNIT_ASSERT_EQUAL(v0.o,   0.0);
     }
 
     /* copy assignment */ {
@@ -38,12 +46,12 @@ TEST_F(TVec3DTest, Construct)
         v3.r.x = 3.1;
         v3.r.y = 3.2;
         v3.o = 3.3;
-        EXPECT_EQ(3.1, v3.r.x);
-        EXPECT_EQ(3.2, v3.r.y);
-        EXPECT_EQ(3.3, v3.o);
-        EXPECT_EQ(0, v0.r.x);
-        EXPECT_EQ(0, v0.r.y);
-        EXPECT_EQ(0, v0.o);
+        CPPUNIT_ASSERT_EQUAL(v3.r.x, 3.1);
+        CPPUNIT_ASSERT_EQUAL(v3.r.y, 3.2);
+        CPPUNIT_ASSERT_EQUAL(v3.o,   3.3);
+        CPPUNIT_ASSERT_EQUAL(v0.r.x, 0.0);
+        CPPUNIT_ASSERT_EQUAL(v0.r.y, 0.0);
+        CPPUNIT_ASSERT_EQUAL(v0.o,   0.0);
     }
 
     /* move constructor */ {
@@ -51,12 +59,12 @@ TEST_F(TVec3DTest, Construct)
         v4.r.x = 4.1;
         v4.r.y = 4.2;
         v4.o = 4.3;
-        EXPECT_EQ(4.1, v4.r.x);
-        EXPECT_EQ(4.2, v4.r.y);
-        EXPECT_EQ(4.3, v4.o);
-        EXPECT_EQ(0, v0.r.x);
-        EXPECT_EQ(0, v0.r.y);
-        EXPECT_EQ(0, v0.o);
+        CPPUNIT_ASSERT_EQUAL(v4.r.x, 4.1);
+        CPPUNIT_ASSERT_EQUAL(v4.r.y, 4.2);
+        CPPUNIT_ASSERT_EQUAL(v4.o,   4.3);
+        CPPUNIT_ASSERT_EQUAL(v0.r.x, 0.0);
+        CPPUNIT_ASSERT_EQUAL(v0.r.y, 0.0);
+        CPPUNIT_ASSERT_EQUAL(v0.o,   0.0);
     }
 
     /* move assignment */ {
@@ -64,11 +72,11 @@ TEST_F(TVec3DTest, Construct)
         v5.r.x = 5.1;
         v5.r.y = 5.2;
         v5.o = 5.3;
-        EXPECT_EQ(5.1, v5.r.x);
-        EXPECT_EQ(5.2, v5.r.y);
-        EXPECT_EQ(5.3, v5.o);
-        EXPECT_EQ(0, v0.r.x);
-        EXPECT_EQ(0, v0.r.y);
-        EXPECT_EQ(0, v0.o);
+        CPPUNIT_ASSERT_EQUAL(v5.r.x, 5.1);
+        CPPUNIT_ASSERT_EQUAL(v5.r.y, 5.2);
+        CPPUNIT_ASSERT_EQUAL(v5.o,   5.3);
+        CPPUNIT_ASSERT_EQUAL(v0.r.x, 0.0);
+        CPPUNIT_ASSERT_EQUAL(v0.r.y, 0.0);
+        CPPUNIT_ASSERT_EQUAL(v0.o,   0.0);
     }
 }

--- a/pytest/conftest.py
+++ b/pytest/conftest.py
@@ -94,7 +94,8 @@ class Env:
 
         output = self.run(
             ['vvplot', ifile, ofile] + args,
-            cwd=self.tempdir
+            cwd=self.tempdir,
+            timeout = 30
         )
         output.ifile = ifile
         output.ofile = ofile

--- a/utils/vvcompose/CMakeLists.txt
+++ b/utils/vvcompose/CMakeLists.txt
@@ -52,4 +52,4 @@ add_custom_command(
 add_custom_target(vvcompose_test.lua ALL
     DEPENDS ${CMAKE_BINARY_DIR}/tests/vvcompose_test.lua)
 
-add_test(vvcompose_test vvcompose ${CMAKE_BINARY_DIR}/tests/vvcompose_test.lua)
+# add_test(vvcompose_test vvcompose ${CMAKE_BINARY_DIR}/tests/vvcompose_test.lua)

--- a/utils/vvcompose/CMakeLists.txt
+++ b/utils/vvcompose/CMakeLists.txt
@@ -52,4 +52,4 @@ add_custom_command(
 add_custom_target(vvcompose_test.lua ALL
     DEPENDS ${CMAKE_BINARY_DIR}/tests/vvcompose_test.lua)
 
-# add_test(vvcompose_test vvcompose ${CMAKE_BINARY_DIR}/tests/vvcompose_test.lua)
+add_test(vvcompose_test vvcompose ${CMAKE_BINARY_DIR}/tests/vvcompose_test.lua)


### PR DESCRIPTION
Since we've embedded almost all dependencies, the `googletest` framework is now being built as a part of the project. But some of our hardware doesn't have modern enough GCC and can't build it, so it's replaced with a lighter `cppunit`.